### PR TITLE
Change the executable in windows case.

### DIFF
--- a/pyjasper/jasperpy.py
+++ b/pyjasper/jasperpy.py
@@ -57,8 +57,7 @@ class JasperPy:
         if not input_file:
             raise NameError('No input file!')
 
-        command = EXECUTABLE if self.windows \
-            else self.path_executable + '/' + EXECUTABLE
+        command = self.path_executable + '/' + EXECUTABLE
 
         command += ' compile '
         command += "\"%s\"" % input_file
@@ -82,8 +81,7 @@ class JasperPy:
         else:
             raise NameError("'format_list' value is not list!")
 
-        command = EXECUTABLE if self.windows \
-            else self.path_executable + '/' + EXECUTABLE
+        command = self.path_executable + '/' + EXECUTABLE
 
         command += " --locale %s" % locale
         command += ' process '


### PR DESCRIPTION
When I start using lib in Windows (10), I've run into problem that "jasperstarter" couldn't be found. Small investigation and problem was found "EXECUTABLE if self.windows " but EXECUTABLE is just string "jasperstarter" without path to that file. So, my change is to remove windows case "self.path_executable + '/' + EXECUTABLE".